### PR TITLE
Improve Qdrant endpoint handling for better user experience

### DIFF
--- a/cmd/migrate_from_qdrant_test.go
+++ b/cmd/migrate_from_qdrant_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"net/url"
+	"strings"
 	"testing"
 )
 
@@ -19,12 +20,12 @@ func Test_getPort(t *testing.T) {
 		{
 			name:     "tls enabled, default port",
 			url:      &url.URL{Scheme: "https", Host: "localhost"},
-			expected: 443,
+			expected: 6334,
 		},
 		{
 			name:     "tls disabled, default port",
 			url:      &url.URL{Scheme: "http", Host: "localhost"},
-			expected: 80,
+			expected: 6334,
 		},
 		{
 			name:     "tls disabled, custom port",
@@ -37,6 +38,214 @@ func Test_getPort(t *testing.T) {
 			got, _ := getPort(tt.url)
 			if got != tt.expected {
 				t.Errorf("getPort() got = %v, expected %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func Test_parseQdrantUrl(t *testing.T) {
+	tests := []struct {
+		name        string
+		urlStr      string
+		expectedHost string
+		expectedPort int
+		expectedTLS  bool
+		expectError  bool
+		errorContains string
+	}{
+		{
+			name:        "valid GRPC URL with port",
+			urlStr:      "http://localhost:6334",
+			expectedHost: "localhost",
+			expectedPort: 6334,
+			expectedTLS:  false,
+			expectError:  false,
+		},
+		{
+			name:        "valid HTTPS GRPC URL with port",
+			urlStr:      "https://cluster.qdrant.com:6334",
+			expectedHost: "cluster.qdrant.com",
+			expectedPort: 6334,
+			expectedTLS:  true,
+			expectError:  false,
+		},
+		{
+			name:        "HTTP URL without port defaults to GRPC port",
+			urlStr:      "http://localhost",
+			expectedHost: "localhost",
+			expectedPort: 6334,
+			expectedTLS:  false,
+			expectError:  false,
+		},
+		{
+			name:        "HTTPS URL without port defaults to GRPC port",
+			urlStr:      "https://cluster.qdrant.com",
+			expectedHost: "cluster.qdrant.com",
+			expectedPort: 6334,
+			expectedTLS:  true,
+			expectError:  false,
+		},
+		{
+			name:        "HTTPS URL with explicit port 443 shows warning",
+			urlStr:      "https://cluster.qdrant.com:443",
+			expectedHost: "cluster.qdrant.com",
+			expectedPort: 443,
+			expectedTLS:  true,
+			expectError:  false,
+		},
+		{
+			name:        "REST port should warn but not fail",
+			urlStr:      "http://localhost:6333",
+			expectedHost: "localhost",
+			expectedPort: 6333,
+			expectedTLS:  false,
+			expectError:  false,
+		},
+		{
+			name:        "HTTPS REST port should warn but not fail",
+			urlStr:      "https://cluster.qdrant.com:6333",
+			expectedHost: "cluster.qdrant.com",
+			expectedPort: 6333,
+			expectedTLS:  true,
+			expectError:  false,
+		},
+		{
+			name:        "invalid port should fail",
+			urlStr:      "http://localhost:invalid",
+			expectError:  true,
+			errorContains: "invalid port",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			host, port, tls, err := parseQdrantUrl(tt.urlStr)
+			
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("parseQdrantUrl() expected error but got none")
+					return
+				}
+				if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("parseQdrantUrl() error = %v, expected to contain %v", err, tt.errorContains)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("parseQdrantUrl() unexpected error = %v", err)
+				return
+			}
+
+			if host != tt.expectedHost {
+				t.Errorf("parseQdrantUrl() host = %v, expected %v", host, tt.expectedHost)
+			}
+			if port != tt.expectedPort {
+				t.Errorf("parseQdrantUrl() port = %v, expected %v", port, tt.expectedPort)
+			}
+			if tls != tt.expectedTLS {
+				t.Errorf("parseQdrantUrl() tls = %v, expected %v", tls, tt.expectedTLS)
+			}
+		})
+	}
+}
+
+func Test_validateQdrantPort(t *testing.T) {
+	tests := []struct {
+		name        string
+		urlStr      string
+		port        int
+		expectError bool
+		errorContains string
+	}{
+		{
+			name:        "valid GRPC port",
+			urlStr:      "http://localhost:6334",
+			port:        6334,
+			expectError: false,
+		},
+		{
+			name:        "REST port should warn but not fail",
+			urlStr:      "http://localhost:6333",
+			port:        6333,
+			expectError: false,
+		},
+		{
+			name:        "custom port should pass",
+			urlStr:      "http://localhost:8080",
+			port:        8080,
+			expectError: false,
+		},
+		{
+			name:        "HTTPS default port should pass but warn",
+			urlStr:      "https://cluster.qdrant.com",
+			port:        443,
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parsedUrl, _ := url.Parse(tt.urlStr)
+			err := validateQdrantPort(parsedUrl, tt.port)
+			
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("validateQdrantPort() expected error but got none")
+					return
+				}
+				if tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
+					t.Errorf("validateQdrantPort() error = %v, expected to contain %v", err, tt.errorContains)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("validateQdrantPort() unexpected error = %v", err)
+			}
+		})
+	}
+}
+
+func Test_probeEndpointType(t *testing.T) {
+	tests := []struct {
+		name        string
+		host        string
+		port        int
+		useTLS      bool
+		expectRest  bool
+		expectError bool
+	}{
+		{
+			name:        "non-existent endpoint should return error",
+			host:        "non-existent-host-12345",
+			port:        6334,
+			useTLS:      false,
+			expectRest:  false,
+			expectError: true,
+		},
+		{
+			name:        "localhost with invalid port should return error",
+			host:        "localhost",
+			port:        99999,
+			useTLS:      false,
+			expectRest:  false,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isRest, err := probeEndpointType(tt.host, tt.port, tt.useTLS, "")
+			
+			if tt.expectError && err == nil {
+				t.Errorf("probeEndpointType() expected error but got none")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("probeEndpointType() unexpected error: %v", err)
+			}
+			if isRest != tt.expectRest {
+				t.Errorf("probeEndpointType() isRest = %v, expected %v", isRest, tt.expectRest)
 			}
 		})
 	}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -130,7 +130,7 @@ func validateQdrantPort(parsedUrl *url.URL, port int) error {
 
 	// Warn about HTTPS with port 443 (likely REST endpoint)
 	if parsedUrl.Scheme == HTTPS && port == HTTPS_DEFAULT_PORT {
-		pterm.Warning.Printfln("Using HTTPS with port %d. Qdrant cloud instances typically serve REST on port %d and GRPC on port %d", HTTPS_DEFAULT_PORT, HTTPS_DEFAULT_PORT, QDRANT_GRPC_PORT)
+		pterm.Warning.Printfln("Using HTTPS with port %d. Qdrant typically serves REST on port %d and GRPC on port %d", HTTPS_DEFAULT_PORT, HTTPS_DEFAULT_PORT, QDRANT_GRPC_PORT)
 		pterm.Warning.Printfln("If you encounter connection issues, try specifying the GRPC port explicitly: %s:%d", parsedUrl.Host, QDRANT_GRPC_PORT)
 	}
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
@@ -15,9 +18,27 @@ import (
 	"github.com/qdrant/go-client/qdrant"
 )
 
-const HTTPS = "https"
+const (
+	HTTPS                = "https"
+	QDRANT_REST_PORT     = 6333
+	QDRANT_GRPC_PORT     = 6334
+	HTTPS_DEFAULT_PORT   = 443
+	HTTP_DEFAULT_PORT    = 80
+)
 
 func connectToQdrant(globals *Globals, host string, port int, apiKey string, useTLS bool, maxMessageSize int) (*qdrant.Client, error) {
+	// If this looks like a REST port, probe the endpoint to verify
+	if port == QDRANT_REST_PORT {
+		pterm.Info.Println("Probing endpoint to verify protocol type...")
+		isRest, probeErr := probeEndpointType(host, port, useTLS, apiKey)
+		if probeErr != nil && isRest {
+			return nil, probeErr
+		}
+		if isRest {
+			return nil, fmt.Errorf("confirmed: endpoint is serving REST API, but this tool requires GRPC")
+		}
+		pterm.Info.Println("Endpoint probe successful - proceeding with GRPC connection")
+	}
 	debugLogger := logging.LoggerFunc(func(ctx context.Context, lvl logging.Level, msg string, fields ...any) {
 		pterm.Debug.Printf(msg, fields...)
 	})
@@ -67,14 +88,15 @@ func getPort(u *url.URL) (int, error) {
 	if u.Port() != "" {
 		sourcePort, err := strconv.Atoi(u.Port())
 		if err != nil {
-			return 0, fmt.Errorf("failed to parse source port: %w", err)
+			return 0, fmt.Errorf("failed to parse port: %w", err)
 		}
 		return sourcePort, nil
-	} else if u.Scheme == HTTPS {
-		return 443, nil
 	}
-
-	return 80, nil
+	
+	// Since this tool only uses GRPC, default to GRPC port regardless of scheme
+	// This is more user-friendly than defaulting to HTTP/HTTPS ports
+	pterm.Info.Printfln("No port specified, defaulting to GRPC port %d", QDRANT_GRPC_PORT)
+	return QDRANT_GRPC_PORT, nil
 }
 
 func parseQdrantUrl(urlStr string) (host string, port int, tls bool, err error) {
@@ -90,7 +112,95 @@ func parseQdrantUrl(urlStr string) (host string, port int, tls bool, err error) 
 		return "", 0, false, fmt.Errorf("failed to parse port: %w", err)
 	}
 
+	// Validate and provide user-friendly warnings for common port issues
+	err = validateQdrantPort(parsedUrl, port)
+	if err != nil {
+		return "", 0, false, err
+	}
+
 	return host, port, tls, nil
+}
+
+func validateQdrantPort(parsedUrl *url.URL, port int) error {
+	// Warn if user provided REST port when GRPC is expected
+	if port == QDRANT_REST_PORT {
+		pterm.Warning.Printfln("Detected port %d which is typically used for Qdrant REST API", QDRANT_REST_PORT)
+		pterm.Warning.Printfln("This tool uses GRPC and typically expects port %d. Will attempt connection and verify endpoint type", QDRANT_GRPC_PORT)
+	}
+
+	// Warn about HTTPS with port 443 (likely REST endpoint)
+	if parsedUrl.Scheme == HTTPS && port == HTTPS_DEFAULT_PORT {
+		pterm.Warning.Printfln("Using HTTPS with port %d. Qdrant cloud instances typically serve REST on port %d and GRPC on port %d", HTTPS_DEFAULT_PORT, HTTPS_DEFAULT_PORT, QDRANT_GRPC_PORT)
+		pterm.Warning.Printfln("If you encounter connection issues, try specifying the GRPC port explicitly: %s:%d", parsedUrl.Host, QDRANT_GRPC_PORT)
+	}
+
+	return nil
+}
+
+// probeEndpointType attempts to determine if an endpoint is REST or GRPC
+func probeEndpointType(host string, port int, useTLS bool, apiKey string) (isRest bool, err error) {
+	// First try a simple GRPC health check
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Try to create a GRPC client and make a simple call
+	client, err := qdrant.NewClient(&qdrant.Config{
+		Host:                   host,
+		Port:                   port,
+		APIKey:                 apiKey,
+		UseTLS:                 useTLS,
+		TLSConfig:              &tls.Config{InsecureSkipVerify: true},
+		SkipCompatibilityCheck: true,
+	})
+	if err == nil {
+		// Try a simple GRPC call - list collections
+		_, grpcErr := client.ListCollections(ctx)
+		if grpcErr == nil {
+			return false, nil // Successfully made GRPC call
+		}
+		// If GRPC call failed, check if it's a protocol-level error that suggests REST endpoint
+		if strings.Contains(grpcErr.Error(), "malformed header") || 
+		   strings.Contains(grpcErr.Error(), "transport: received the unexpected content-type") ||
+		   strings.Contains(grpcErr.Error(), "http2: server sent GOAWAY") {
+			// These errors suggest we're talking to a REST endpoint
+			return true, fmt.Errorf("endpoint appears to be serving REST API, but GRPC is required")
+		}
+	}
+
+	// If GRPC client creation failed or gave ambiguous errors, try REST probe
+	scheme := "http"
+	if useTLS {
+		scheme = "https"
+	}
+	
+	restURL := fmt.Sprintf("%s://%s:%d/collections", scheme, host, port)
+	req, err := http.NewRequestWithContext(ctx, "GET", restURL, nil)
+	if err != nil {
+		return false, fmt.Errorf("failed to create REST probe request: %w", err)
+	}
+	
+	if apiKey != "" {
+		req.Header.Set("api-key", apiKey)
+	}
+	
+	httpClient := &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+	
+	resp, err := httpClient.Do(req)
+	if err == nil {
+		resp.Body.Close()
+		if resp.StatusCode == 200 || resp.StatusCode == 401 || resp.StatusCode == 403 {
+			// Got a valid HTTP response from /collections endpoint
+			return true, fmt.Errorf("endpoint is serving REST API on /collections, but this tool requires GRPC")
+		}
+	}
+	
+	// If both probes failed, return the original error (connection issue, etc.)
+	return false, fmt.Errorf("unable to determine endpoint type - connection may be failing")
 }
 
 func validateBatchSize(batchSize int) error {


### PR DESCRIPTION
## Problem

The migration tool was confusing when users provided bare URLs (like `https://cluster.qdrant.com/`) because:

1. **Wrong port defaults**: Bare URLs defaulted to HTTP/HTTPS ports (80/443) instead of GRPC port (6334)
2. **Cryptic errors**: Tool would connect to REST endpoints but try to speak GRPC, giving misleading permission errors
3. **Poor UX**: Users had to manually specify `:6334` even though the tool only uses GRPC

## Solution

### 🎯 Smart Port Defaulting
- **Before**: `https://cluster.qdrant.com` → port 443 (wrong!)
- **After**: `https://cluster.qdrant.com` → port 6334 (correct!) with helpful message

### 🔍 Intelligent Endpoint Probing  
- Detects when REST port (6333) is used
- Shows clear warnings instead of cryptic errors
- Probes endpoints to verify protocol compatibility

### 💬 Enhanced User Messages
- Clear info when defaulting to GRPC port
- Specific warnings for Qdrant cloud instances using port 443
- Helpful guidance for common misconfigurations

## Changes

- **`cmd/utils.go`**: Updated `getPort()` to default to GRPC port 6334 for all bare URLs
- **`cmd/utils.go`**: Enhanced `validateQdrantPort()` with better warning logic
- **`cmd/migrate_from_qdrant_test.go`**: Updated all tests to reflect new behavior

## Testing

- ✅ All unit tests updated and passing
- ✅ Manual testing confirms expected behavior:
  - `https://cluster.qdrant.com` → defaults to 6334 with info message
  - `http://localhost:6333` → warns and probes endpoint  
  - `https://cluster.qdrant.com:443` → shows cloud-specific warning

## Impact

This makes the tool much more user-friendly for the common case of Qdrant cloud instances, eliminating the need to manually specify `:6334` while providing clear guidance when issues occur.

@jeffwilde can click here to [continue refining the PR](https://app.all-hands.dev/conversations/88308aa1098d4275b1e9dc8948527ee2)